### PR TITLE
Support date passed as a String

### DIFF
--- a/lib/to_timezone/tz_ext.rb
+++ b/lib/to_timezone/tz_ext.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require_relative 'tzs'
-require 'active_support/core_ext/time'
+require_relative "tzs"
+require "active_support/core_ext/time"
 
 module ToTimezone
   module TzExt
     ToTimezone::Tzs::TIMEZONES.each do |abbr, timezone|
       define_method("to_#{abbr}") do
-        self.utc.in_time_zone(timezone)
+        time = is_a?(String) ? Time.parse(self) : self
+        time.utc.in_time_zone(timezone)
       end
     end
   end
@@ -19,6 +20,10 @@ class Time
 end
 
 class DateTime
+  include ToTimezone::TzExt
+end
+
+class String
   include ToTimezone::TzExt
 end
 

--- a/lib/to_timezone/tz_ext.rb
+++ b/lib/to_timezone/tz_ext.rb
@@ -2,13 +2,13 @@
 
 require_relative "tzs"
 require "active_support/core_ext/time"
+require "active_support/core_ext/string/zones"
 
 module ToTimezone
   module TzExt
     ToTimezone::Tzs::TIMEZONES.each do |abbr, timezone|
       define_method("to_#{abbr}") do
-        time = is_a?(String) ? Time.parse(self) : self
-        time.utc.in_time_zone(timezone)
+        utc.in_time_zone(timezone)
       end
     end
   end
@@ -25,6 +25,10 @@ end
 
 class String
   include ToTimezone::TzExt
+
+  def utc
+    in_time_zone("UTC")
+  end
 end
 
 # Explicitly patch ActiveSupport::TimeWithZone

--- a/lib/to_timezone/version.rb
+++ b/lib/to_timezone/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ToTimezone
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/lib/to_timezone/tz_ext_spec.rb
+++ b/spec/lib/to_timezone/tz_ext_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe ToTimezone::TzExt do
   context "when using valid timezone" do
-    it "returns datetime with coverted timezone" do
+    it "returns datetime with converted timezone" do
       timestamp = DateTime.parse("2025-02-07 07:00:00 +0800")
 
       expect(timestamp.to_utc.to_s).to eq("2025-02-06 23:00:00 UTC")
@@ -10,7 +10,7 @@ RSpec.describe ToTimezone::TzExt do
   end
 
   context "when pass date is a string" do
-    it "returns datetime with coverted timezone" do
+    it "returns datetime with converted timezone" do
       timestamp = "2025-02-07 07:00:00 +0800"
 
       expect(timestamp.to_utc.to_s).to eq("2025-02-06 23:00:00 UTC")

--- a/spec/lib/to_timezone/tz_ext_spec.rb
+++ b/spec/lib/to_timezone/tz_ext_spec.rb
@@ -1,11 +1,19 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe ToTimezone::TzExt do
-  context 'when using valid timezone' do
-    it 'returns datetime with coverted timezone' do
+  context "when using valid timezone" do
+    it "returns datetime with coverted timezone" do
       timestamp = DateTime.parse("2025-02-07 07:00:00 +0800")
 
-      expect(timestamp.to_utc.to_s).to eq('2025-02-06 23:00:00 UTC')
+      expect(timestamp.to_utc.to_s).to eq("2025-02-06 23:00:00 UTC")
+    end
+  end
+
+  context "when pass date is a string" do
+    it "returns datetime with coverted timezone" do
+      timestamp = "2025-02-07 07:00:00 +0800"
+
+      expect(timestamp.to_utc.to_s).to eq("2025-02-06 23:00:00 UTC")
     end
   end
 end


### PR DESCRIPTION
## Add suuport when date passed is a String it will convert the string into time so we can parse it in specific timezone